### PR TITLE
Fix Elixir 1.4 compile warnings

### DIFF
--- a/lib/ex_guard/notifier.ex
+++ b/lib/ex_guard/notifier.ex
@@ -23,7 +23,7 @@ defmodule ExGuard.Notifier do
   def notify(opts) do
     opts = opts
       |> Keyword.put(:content_image, content_image(opts[:status]))
-      |> Keyword.put(:icon, get_icon)
+      |> Keyword.put(:icon, get_icon())
 
     @notifiers
     |> Enum.filter(fn (n) -> apply(n, :available?, []) end)
@@ -33,9 +33,9 @@ defmodule ExGuard.Notifier do
 
   defp content_image(status) do
     case status do
-      :ok -> "#{base_dir}/priv/icons/Success.icns"
-      :error -> "#{base_dir}/priv/icons/Failed.icns"
-      :pending -> "#{base_dir}/priv/icons/Failed.icns"
+      :ok -> "#{base_dir()}/priv/icons/Success.icns"
+      :error -> "#{base_dir()}/priv/icons/Failed.icns"
+      :pending -> "#{base_dir()}/priv/icons/Failed.icns"
       _ -> ""
     end
   end

--- a/lib/ex_guard/notifier.ex
+++ b/lib/ex_guard/notifier.ex
@@ -41,7 +41,7 @@ defmodule ExGuard.Notifier do
   end
 
   defp get_icon do
-    "#{base_dir}/priv/icons/Guard.icns"
+    "#{base_dir()}/priv/icons/Guard.icns"
   end
 
   defp base_dir do

--- a/lib/mix/tasks/guard.ex
+++ b/lib/mix/tasks/guard.ex
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Guard do
   def run(args) do
     case OptionParser.parse(args) do
       {[config: config_file], _, _} -> execute(config_file)
-      {[], [], []} -> execute(get_config_file)
+      {[], [], []} -> execute(get_config_file())
       _ ->
         IO.puts "invalid option, try 'mix help guard'"
         System.halt(1)

--- a/mix.exs
+++ b/mix.exs
@@ -9,9 +9,9 @@ defmodule ExGuard.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
-     package: package,
-     description: description,
+     deps: deps(),
+     package: package(),
+     description: description(),
 
      name: "ExGuard",
      docs: [source_ref: "#{@version}", main: "Mix.Tasks.Guard", logo: "logo-white.png"],


### PR DESCRIPTION
Remove Elixir compile warnings for missing parenthesis in zero-arity functions.