### PR TITLE
execute command in batch

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,0 @@
-1.2.0
-2017-02-06
-	* elixir 1.4 compatibility
-
-0.10.0
-2016-03-21
-	* added notify-send

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## [1.3.0] - 2017-09-01
+### Changed
+- execute command in batch

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ ExGuard is a mix command to handle events on file system modifications, ExGuard 
 
     ```elixir
     def deps do
-      [{:ex_guard, "~> 1.2", only: :dev}]
+      [{:ex_guard, "~> 1.3", only: :dev}]
     end
     ```
 
@@ -31,6 +31,7 @@ ExGuard is a mix command to handle events on file system modifications, ExGuard 
     guard("unit-test")
     |> command("mix test --color")
     |> watch(~r{\.(erl|ex|exs|eex|xrl|yrl)\z}i)
+    |> ignore(~r{deps})
     |> notification(:auto)
     ```
 

--- a/lib/ex_guard.ex
+++ b/lib/ex_guard.ex
@@ -4,6 +4,8 @@ defmodule ExGuard do
   triggers commands and notifications
   """
 
+  defstruct changed_files: []
+
   use GenServer
   alias ExGuard.Guard
   alias ExGuard.Config
@@ -16,19 +18,41 @@ defmodule ExGuard do
 
   @doc false
   def init(_) do
+    :erlang.send_after(2000, self(), :handle_file_changes)
     :ok = :fs.subscribe
-    {:ok, Map.new}
+    {:ok, %ExGuard{}}
   end
 
   @doc """
   Executes on file changes
   """
-  def handle_info({_pid, {:fs, :file_event}, {path, _event}}, state) do
-    path
-    |> to_string
-    |> Config.match_guards
-    |> execute_guards
-    {:noreply, state}
+  def handle_info({_pid, {:fs, :file_event}, {path, event}}, state) do
+    matched? =  path
+                |> to_string
+                |> Config.match_guards
+    changed_files = if matched? == [] do
+      state.changed_files
+    else
+      Enum.uniq(state.changed_files ++ [to_string(path)])
+    end
+    {:noreply, %{state| changed_files: changed_files}}
+  end
+
+  @doc false
+  def handle_info(:handle_file_changes, state) do
+    case state.changed_files do
+      [] -> :noop
+      changed_files ->
+        changed_files
+        |> Enum.map(&Config.match_guards/1)
+        |> List.flatten
+        |> Enum.uniq
+        |> execute_guards
+    end
+
+
+    :erlang.send_after(2000, self(), :handle_file_changes)
+    {:noreply, %{state | changed_files: []}}
   end
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExGuard.Mixfile do
   use Mix.Project
 
-  @version "1.2.0"
+  @version "1.3.0"
 
   def project do
     [app: :ex_guard,


### PR DESCRIPTION
This is a fix request for issue #6 

When files are changed, instead of running the command immediately keep
it in internal state and run through them every 2 seconds. the benefits
are :

* prevent executing the command for same file twice. depends on editor
  sometimes we receive the file change notification twice
* try to find the patterns that match with changed files and avoid
  executing the command twice.