### PR TITLE
Umbrella app support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.4.0]
+### Changed
+- strip `app/my_app` from file if configured with `umbrella_app: true`
+
+## [1.3.3]
+### Fixed
+- Compiler warnings for Elixir 1.7
+
 ## [1.3.2]
 ### Removed
 - Support for Elixir <= 1.2

--- a/lib/ex_guard/guard.ex
+++ b/lib/ex_guard/guard.ex
@@ -93,6 +93,14 @@ defmodule ExGuard.Guard do
   If files is a list, append them to guard.cmd and executes it.
   """
   def execute({guard_config, files}) do
+    umbrella_app? = Keyword.get(guard_config.options, :umbrella_app, false)
+    files = if umbrella_app? do
+      Enum.map(files, fn path ->
+        String.replace(path, ~r{^apps/[a-zA-z_]+/}, "")
+      end)
+    else
+      files
+    end
     arg = Enum.join(files, " ")
     cmd = String.trim("#{guard_config.cmd} #{arg}")
     IO.puts("ex_guard is executing #{cmd}")

--- a/lib/ex_guard/guard.ex
+++ b/lib/ex_guard/guard.ex
@@ -17,9 +17,12 @@ defmodule ExGuard.Guard do
 
       guard("test")
 
-  If you want to run the command on start set `:run_on_start` option
+  Options:
 
-      guard("test", run_on_start: true)
+    * `:run_on_start`, set this option If you want to run the command when `mix guard` has been executed
+    * `:umbrella_app`, set this option If you are running guard on the main directory of an umbrella project and using `watch` command to match changed filed with test
+
+      guard("test", run_on_start: true, umbrella_app: true)
   """
   def guard(title, opts \\ []) do
     guard_struct = %ExGuard.Guard{title: title, options: opts}
@@ -94,13 +97,16 @@ defmodule ExGuard.Guard do
   """
   def execute({guard_config, files}) do
     umbrella_app? = Keyword.get(guard_config.options, :umbrella_app, false)
-    files = if umbrella_app? do
-      Enum.map(files, fn path ->
-        String.replace(path, ~r{^apps/[a-zA-z_]+/}, "")
-      end)
-    else
-      files
-    end
+
+    files =
+      if umbrella_app? do
+        Enum.map(files, fn path ->
+          String.replace(path, ~r{^apps/[a-zA-z_]+/}, "")
+        end)
+      else
+        files
+      end
+
     arg = Enum.join(files, " ")
     cmd = String.trim("#{guard_config.cmd} #{arg}")
     IO.puts("ex_guard is executing #{cmd}")

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExGuard.Mixfile do
   use Mix.Project
 
-  @version "1.3.3"
+  @version "1.4.0"
 
   def project do
     [


### PR DESCRIPTION
When guard detects a file has been changes, it executes `watch` options
to possibaly match with watch configuration. In umbrella app, if mix
guard is running from main directory, the changed file has prefix of
`app/my_app/test/my_module_test.exs`. This fix would remove `app/my_app`
from the file name and only pass `test/my_module_test.exs` to `watch`
function