### PR TITLE
Add support to run specific guards

### DIFF
--- a/lib/ex_guard/config.ex
+++ b/lib/ex_guard/config.ex
@@ -42,6 +42,10 @@ defmodule ExGuard.Config do
     Agent.get(__MODULE__, &Keyword.values(&1))
   end
 
+  def remove_guard(title) do
+    Agent.update(__MODULE__, &Keyword.delete(&1, String.to_atom(title)))
+  end
+
   @doc """
   Given the path, returns matched guard configs.
 

--- a/lib/ex_guard/guard.ex
+++ b/lib/ex_guard/guard.ex
@@ -109,7 +109,7 @@ defmodule ExGuard.Guard do
 
     arg = Enum.join(files, " ")
     cmd = String.trim("#{guard_config.cmd} #{arg}")
-    IO.puts("ex_guard is executing #{cmd}")
+    Mix.Shell.IO.info("ex_guard is executing #{guard_config.title}")
 
     case Mix.Shell.IO.cmd(cmd) do
       0 -> {:ok, 0, "", guard_config}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExGuard.Mixfile do
   use Mix.Project
 
-  @version "1.4.0"
+  @version "1.5.0"
 
   def project do
     [


### PR DESCRIPTION
The idea is to run `mix guard unit-testing` and run the specific guard titled `unit-testing`, even if there are more guards inside config file.
Another change is the default message `ex_guard is executing` to  show the guard title instead of the command.
The command `mix guard` is unchanged.